### PR TITLE
Update tablearray.csv

### DIFF
--- a/tablearray.csv
+++ b/tablearray.csv
@@ -1374,7 +1374,7 @@ X O,X's & O's,Bally 1984,"X,O,Bally,1984","black,steel,king,granny,hunter",
 Xenon,Xenon,Bally 1980,,,
 Yamanobori - Mountain Climbing Game,Yamanobori Mountain Climbing Game,Komaya 1981,yamanobori,,
 Yellow Submarine,Yellow Submarine,Original 2021,,,yellowsub.txt
-You’ll Shoot Your Eye Out!,You’ll Shoot Your Eye Out!,Original 2024,,,
+You'll Shoot Your Eye Out!,You'll Shoot Your Eye Out!,Original 2024,,,
 Young Frankenstein,Young Frankenstein,Original 2016,,,
 Zarza,Zarza,Taito 1982,,,
 Zeke's Peak,Zeke's Peak,Taito 1984,"Zeke,Peak,Taito,1984",,
@@ -1383,6 +1383,7 @@ Zip-A-Doo,Zip-A-Doo,Bally 1970,"Zip,Doo,Bally,1970",,ZipADoo_70VPX.txt
 Zira,Zira,Playmatic 1980,,,
 Zissou,Zissou,Original 2020,"Zissou,Original,2020",,Zissou.txt
 Zodiac,Zodiac,Wiliams 1971,,,
+
 
 
 


### PR DESCRIPTION
The entry for "You'll Shoot Your Eye Out!" had a curly apostrophe in the name rather than a straight apostrophe. All other table names that have an apostrophe have a straight apostrophe. The table "You'll Shoot Your Eye Out!" wasn't showing up in the VPX Launcher list because VPX Launcher was interpreting the apostrophe in the name as a question mark character and wasn't matching. Therefore, the only way to display the table in the list was under the Filebrowser filter. By changing the curly apostrophe to a straight apostrophe, I'm hoping that the table will then be listed with the rest of the tables.